### PR TITLE
Add data to heartbeat message

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -157,7 +157,7 @@ loop:
 			c.Response().Flush()
 			deliveredMessagesMetric.Inc()
 		case <-ticker.C:
-			_, err = fmt.Fprintf(c.Response(), "event: heartbeat\n\n")
+			_, err = fmt.Fprintf(c.Response(), "event: heartbeat\r\ndata: \r\n\n")
 			if err != nil {
 				log.Errorf("ticker can't write to connection: %v", err)
 				break loop


### PR DESCRIPTION
We can't access heartbeat events right now, because the heartbeat without a data section breaks the specification https://html.spec.whatwg.org/multipage/server-sent-events.html#dispatchMessage